### PR TITLE
fix(a11y): hide BackToTop button from screen readers when not visible

### DIFF
--- a/src/components/ui/back-to-top.tsx
+++ b/src/components/ui/back-to-top.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { cn } from '@/lib/utils';
+
+interface BackToTopProps {
+  className?: string;
+  showAfter?: number;
+}
+
+export function BackToTop({ className, showAfter = 400 }: BackToTopProps) {
+  const [isVisible, setIsVisible] = useState(false);
+
+  useEffect(() => {
+    const toggleVisibility = () => {
+      if (window.scrollY > showAfter) {
+        setIsVisible(true);
+      } else {
+        setIsVisible(false);
+      }
+    };
+
+    // Check initial scroll position
+    toggleVisibility();
+
+    window.addEventListener('scroll', toggleVisibility);
+    return () => window.removeEventListener('scroll', toggleVisibility);
+  }, [showAfter]);
+
+  const scrollToTop = () => {
+    window.scrollTo({
+      top: 0,
+      behavior: 'smooth',
+    });
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={scrollToTop}
+      className={cn(
+        'fixed bottom-6 right-6 z-50 flex h-12 w-12 items-center justify-center rounded-full border border-[var(--color-border)] bg-[var(--color-card)] shadow-lg transition-all hover:bg-[var(--color-bg-alt)]',
+        isVisible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-4 opacity-0',
+        className
+      )}
+      aria-label="Back to top"
+      aria-hidden={!isVisible}
+      tabIndex={isVisible ? 0 : -1}
+    >
+      <svg
+        className="h-5 w-5 text-[var(--color-text)]"
+        fill="none"
+        viewBox="0 0 24 24"
+        stroke="currentColor"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          strokeWidth={2}
+          d="M5 10l7-7m0 0l7 7m-7-7v18"
+        />
+      </svg>
+    </button>
+  );
+}

--- a/tests/components/ui/back-to-top.test.tsx
+++ b/tests/components/ui/back-to-top.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BackToTop } from '@/components/ui/back-to-top';
+
+describe('BackToTop', () => {
+  beforeEach(() => {
+    // Mock window.scrollTo
+    window.scrollTo = vi.fn();
+    // Mock window.scrollY
+    Object.defineProperty(window, 'scrollY', { value: 0, writable: true });
+  });
+
+  it('renders button with correct aria-label', () => {
+    render(<BackToTop />);
+    const button = document.querySelector('button[aria-label="Back to top"]');
+    expect(button).toBeInTheDocument();
+  });
+
+  it('is hidden from accessibility tree when scroll position is at top', () => {
+    render(<BackToTop />);
+    const button = document.querySelector('button[aria-label="Back to top"]');
+    expect(button).toHaveClass('opacity-0');
+    expect(button).toHaveAttribute('tabindex', '-1');
+    expect(button).toHaveAttribute('aria-hidden', 'true');
+  });
+
+  it('becomes visible when scrolled past threshold', () => {
+    render(<BackToTop showAfter={400} />);
+
+    // Simulate scroll
+    Object.defineProperty(window, 'scrollY', { value: 500, writable: true });
+    fireEvent.scroll(window);
+
+    const button = screen.getByRole('button', { name: /back to top/i });
+    expect(button).toHaveClass('opacity-100');
+    expect(button).toHaveAttribute('aria-hidden', 'false');
+  });
+
+  it('scrolls to top when clicked', () => {
+    render(<BackToTop />);
+    const button = document.querySelector('button[aria-label="Back to top"]') as HTMLButtonElement;
+
+    fireEvent.click(button);
+
+    expect(window.scrollTo).toHaveBeenCalledWith({
+      top: 0,
+      behavior: 'smooth',
+    });
+  });
+
+  it('applies custom className', () => {
+    render(<BackToTop className="custom-class" />);
+    const button = document.querySelector('button[aria-label="Back to top"]');
+    expect(button).toHaveClass('custom-class');
+  });
+});


### PR DESCRIPTION
## Summary
Adds `aria-hidden` attribute to the BackToTop button so it's properly hidden from screen readers when not visible.

## Changes
- Add `aria-hidden={!isVisible}` to BackToTop button component
- Update tests to verify aria-hidden behavior

## Context
Flagged by CodeRabbit: the BackToTop button was exposed to screen readers even when visually hidden (opacity-0), which could confuse users relying on assistive technology.

## Testing
- All 169 unit tests pass
- Verified aria-hidden toggles correctly with scroll position

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a floating "Back to Top" button that appears when you scroll down the page
  * Smoothly scrolls the page back to the top when clicked
  * Customizable scroll threshold for when the button appears
  * Fully accessible with keyboard navigation support and screen reader compatibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->