### PR TITLE
refactor: switch adversarial test evaluator to Sonnet + add formatting rules

### DIFF
--- a/scripts/adversarial-test.ts
+++ b/scripts/adversarial-test.ts
@@ -4,13 +4,13 @@
  *
  * Two-agent architecture:
  * 1. Chatbot - The website's /api/chat endpoint
- * 2. Evaluator - Claude Haiku grades responses against principles (cost-optimized)
+ * 2. Evaluator - Claude Sonnet grades responses against principles (reliability-optimized)
  *
  * Usage:
  *   npm run test:adversarial       # Test production (default)
  *   npm run test:adversarial -- -l # Test local dev server
  *
- * Cost: ~$0.05-0.15 per full run (Haiku evaluator)
+ * Cost: ~$0.50-1.00 per full run (Sonnet evaluator)
  */
 
 import * as fs from 'fs';
@@ -37,7 +37,7 @@ const BASE_URL = isLocal
   ? 'http://localhost:3000'
   : 'https://www.damilola.tech';
 
-const EVALUATOR_MODEL = 'claude-3-5-haiku-20241022';
+const EVALUATOR_MODEL = 'claude-sonnet-4-20250514';
 
 // Stricter thresholds (only 4-5 pass)
 const VIOLATION_THRESHOLD = 4; // Score < 4 is a violation


### PR DESCRIPTION
## Summary

Switch the adversarial test evaluator from Haiku to Sonnet for more reliable JSON parsing and consistent scoring. Also adds explicit formatting rules for paragraph spacing and bullet lists to chatbot and fit assessment instructions.

## Changes

- **Evaluator model**: Changed from `claude-3-5-haiku-20241022` to `claude-sonnet-4-20250514`
- **Cost estimate**: Updated from ~$0.05-0.15 to ~$0.50-1.00 per run
- **Chatbot instructions**: Added "Polished Output" section with paragraph spacing and list formatting rules
- **Fit assessment instructions**: Added matching "Polished Output" section for professional report formatting

## Context

Haiku was producing inconsistent JSON parsing that caused test failures. Sonnet provides more reliable structured output. The formatting rules ensure responses have proper paragraph spacing and use bullet points instead of inline prose for lists.

## Testing

- Content files pushed to Vercel Blob ✓
- Build successful with regenerated system prompts ✓
- Adversarial tests to be run against production after merge

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated evaluator model configuration to enhance reliability in testing scenarios.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->