### PR TITLE
fix(ci): use correct admin password for production E2E tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -22,7 +22,9 @@ jobs:
       - name: Detect deployment environment
         id: env
         run: |
-          if [ "${{ github.event.deployment_status.environment }}" = "Production" ]; then
+          env_name="${{ github.event.deployment_status.environment }}"
+          env_name_lower="$(echo "$env_name" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$env_name_lower" =~ ^production ]]; then
             echo "is_production=true" >> $GITHUB_OUTPUT
           else
             echo "is_production=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
## Summary
Fixes E2E tests failing on production deployments by using the correct admin password based on deployment environment.

## Changes
- Add environment detection step to determine if deployment is Production or Preview
- Dynamically select `ADMIN_PASSWORD_PRODUCTION` for Production deployments
- Dynamically select `ADMIN_PASSWORD_PREVIEW` for Preview deployments

## Context
E2E workflow triggers on both Preview and Production deployments, but was only passing `ADMIN_PASSWORD_PREVIEW` to tests. Production deployments require `ADMIN_PASSWORD_PRODUCTION`, causing authentication failures in admin-related E2E tests.

## Testing
- Merge to main triggers both Preview and Production deployments
- Check GitHub Actions E2E workflow runs for both environments
- Verify environment detection step shows correct `is_production` value
- Confirm admin authentication succeeds in both environments

---
Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved CI workflow to detect deployment environment and export its result for downstream steps.
  * Updated test run configuration to select appropriate credentials based on detected environment, ensuring production and preview runs use the correct settings.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->