### PR TITLE
feat(hero): update experience tags to skill-based pills

### DIFF
--- a/src/lib/resume-data.ts
+++ b/src/lib/resume-data.ts
@@ -11,7 +11,15 @@ export const resumeData: ResumeData = {
   github: 'https://github.com/damilola-elegbede',
   location: 'Boulder, CO',
   openToRoles: ['Engineering Manager', 'Senior Engineering Manager', 'Director of Engineering'],
-  experienceTags: ['Ex-Verily', 'Ex-Qualcomm', 'MBA + MS CS'],
+  experienceTags: [
+    'Engineering Management',
+    'Team Leadership',
+    'Cross-functional Leadership',
+    'Strategic Planning',
+    'Stakeholder Management',
+    'People Management',
+    'MBA + MS CS',
+  ],
   experiences: [
     {
       id: 'verily',


### PR DESCRIPTION
## Summary
Replace company-based hero pills with skill-based pills that better signal experience and target roles.

## Changes
- Updated `experienceTags` array in `src/lib/resume-data.ts`
- Replaced company pills (`Ex-Verily`, `Ex-Qualcomm`) with skill-based pills
- New pills: Engineering Management, Team Leadership, Cross-functional Leadership, Strategic Planning, Stakeholder Management, People Management
- Retained education credential (`MBA + MS CS`)

## Context
Company names as pills don't effectively communicate skills or experience level to recruiters. Skill-based pills better align with target roles (Engineering Manager, Senior Engineering Manager, Director of Engineering) and improve the hero section's messaging.

## Testing
- TypeScript typecheck passes
- All 534 unit tests pass
- Visual verification confirms pills render correctly

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated resume competencies to reflect a revised set of professional skill areas and expertise.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->