### PR TITLE
fix(audit): call captureTrafficSource fresh on each page_view

### DIFF
--- a/src/lib/audit-client.ts
+++ b/src/lib/audit-client.ts
@@ -92,8 +92,13 @@ class AuditClient {
 
     // Build metadata with optional traffic source
     const metadata: Record<string, unknown> = { ...options.metadata };
-    if (options.includeTrafficSource && this.trafficSource) {
-      metadata.trafficSource = this.trafficSource;
+    if (options.includeTrafficSource) {
+      // Always call captureTrafficSource() fresh to get current UTM params
+      // (supports shortlink redirects that add UTM params after initial visit)
+      const freshTrafficSource = captureTrafficSource();
+      if (freshTrafficSource) {
+        metadata.trafficSource = freshTrafficSource;
+      }
     }
 
     const event: QueuedEvent = {


### PR DESCRIPTION
## Summary

Fixes the audit client to call `captureTrafficSource()` fresh on each `page_view` event instead of using a stale cached value from initialization.

This is a follow-up to PR #61 - that fix updated `traffic-source.ts` to check UTM params first, but the audit client was still using a cached `this.trafficSource` value set at init time, so shortlink UTM params were never captured.

## Changes

- **`src/lib/audit-client.ts`**: When `includeTrafficSource: true`, call `captureTrafficSource()` fresh instead of using `this.trafficSource` cache

## Context

The audit client singleton initializes once and cached `this.trafficSource` at that time. Even though `captureTrafficSource()` was fixed to return current UTM params, the `track()` method was using the stale cached value.

Now `track()` calls `captureTrafficSource()` fresh when `includeTrafficSource: true`, ensuring UTM params from shortlink redirects are captured correctly.

## Testing

- Verified on preview build that `page_view` events now include correct `trafficSource` metadata when visiting via shortlinks
- All existing tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved traffic source tracking in audit logs to capture fresh data on each event instead of using potentially stale cached information, ensuring more accurate tracking of traffic sources.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->