### PR TITLE
fix(audit): call captureTrafficSource fresh on each page_view

### DIFF
--- a/src/lib/audit-client.ts
+++ b/src/lib/audit-client.ts
@@ -92,8 +92,13 @@ class AuditClient {
 
     // Build metadata with optional traffic source
     const metadata: Record<string, unknown> = { ...options.metadata };
-    if (options.includeTrafficSource && this.trafficSource) {
-      metadata.trafficSource = this.trafficSource;
+    if (options.includeTrafficSource) {
+      // Always call captureTrafficSource() fresh to get current UTM params
+      // (supports shortlink redirects that add UTM params after initial visit)
+      const freshTrafficSource = captureTrafficSource();
+      if (freshTrafficSource) {
+        metadata.trafficSource = freshTrafficSource;
+      }
     }
 
     const event: QueuedEvent = {


### PR DESCRIPTION
The audit client was caching trafficSource at init time and never refreshing it. This meant shortlink redirects (which add UTM params after initial page load) would still report the stale cached value.

Now calls captureTrafficSource() fresh when includeTrafficSource=true, ensuring UTM params from shortlink redirects are captured correctly.