### PR TITLE
fix(rate-limit): Bump MCP and resume-generator rate limits

### DIFF
--- a/src/lib/rate-limit.ts
+++ b/src/lib/rate-limit.ts
@@ -24,8 +24,8 @@ export interface RateLimitConfig {
 export const RATE_LIMIT_CONFIGS = {
   chat: { key: 'chat', limit: 50, windowSeconds: 300 }, // 50 per 5 min
   fitAssessment: { key: 'fit-assessment', limit: 10, windowSeconds: 3600 }, // 10 per hour
-  resumeGenerator: { key: 'resume-generator', limit: 10, windowSeconds: 3600 }, // 10 per hour
-  mcp: { key: 'mcp', limit: 60, windowSeconds: 60 }, // 60 per minute per key+IP
+  resumeGenerator: { key: 'resume-generator', limit: 100, windowSeconds: 3600 }, // 100 per hour
+  mcp: { key: 'mcp', limit: 200, windowSeconds: 60 }, // 200 per minute per key+IP
 } as const;
 
 export interface GenericRateLimitResult {


### PR DESCRIPTION
## Problem

MCP rate limit (60/min) and resume-generator/score-resume limit (10/hr) were too restrictive for batch operations via the MCP server (e.g., Clara's job search scoring pipeline).

## Changes

- **MCP endpoint:** 60 → **200 requests/min** per API key + IP
- **Resume generator + score resume:** 10 → **100 requests/hr** per IP

All access is API-key-gated, so higher limits are safe.

## Verification

33 tests passing across rate-limit and MCP endpoint test suites.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Increased resume generator request limit from 10 to 100 per hour
  * Increased MCP request limit from 60 to 200 per minute

<!-- end of auto-generated comment: release notes by coderabbit.ai -->