### PR TITLE
feat: Activity Feed API for engineering showcase

### DIFF
--- a/src/app/api/v1/activity/route.ts
+++ b/src/app/api/v1/activity/route.ts
@@ -1,0 +1,228 @@
+import { list, put } from "@vercel/blob";
+import { randomUUID } from "crypto";
+import { requireApiKey } from "@/lib/api-key-auth";
+import { apiSuccess, Errors } from "@/lib/api-response";
+import { checkGenericRateLimit, getClientIp } from "@/lib/rate-limit";
+import type { ActivitySummary } from "@/lib/types/activity-summary";
+
+export const runtime = "nodejs";
+
+const ACTIVITY_PREFIX = "damilola.tech/activity/";
+
+const RATE_LIMIT_CONFIG = {
+  key: "activity-post",
+  limit: 10,
+  windowSeconds: 60,
+};
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value) && value >= 0;
+}
+
+function validateBody(
+  body: unknown,
+):
+  | { valid: true; data: Omit<ActivitySummary, "id" | "createdAt"> }
+  | { valid: false; error: string } {
+  if (!body || typeof body !== "object") {
+    return { valid: false, error: "Request body must be a JSON object." };
+  }
+
+  const b = body as Record<string, unknown>;
+
+  // weekEnding
+  if (typeof b.weekEnding !== "string" || isNaN(Date.parse(b.weekEnding))) {
+    return {
+      valid: false,
+      error: "`weekEnding` must be a valid ISO date string.",
+    };
+  }
+
+  // headline
+  if (typeof b.headline !== "string" || b.headline.trim().length === 0) {
+    return {
+      valid: false,
+      error: "`headline` is required and must be a non-empty string.",
+    };
+  }
+  if (b.headline.length > 200) {
+    return {
+      valid: false,
+      error: "`headline` must be 200 characters or fewer.",
+    };
+  }
+
+  // highlights
+  if (
+    !Array.isArray(b.highlights) ||
+    b.highlights.length < 1 ||
+    b.highlights.length > 10
+  ) {
+    return {
+      valid: false,
+      error: "`highlights` must be an array with 1–10 items.",
+    };
+  }
+  if (!b.highlights.every((h) => typeof h === "string")) {
+    return { valid: false, error: "`highlights` must be an array of strings." };
+  }
+
+  // metrics
+  if (!b.metrics || typeof b.metrics !== "object" || Array.isArray(b.metrics)) {
+    return { valid: false, error: "`metrics` must be an object." };
+  }
+  const m = b.metrics as Record<string, unknown>;
+  if (!isNonNegativeInteger(m.prsShipped)) {
+    return {
+      valid: false,
+      error: "`metrics.prsShipped` must be a non-negative integer.",
+    };
+  }
+  if (!isNonNegativeInteger(m.testsPassing)) {
+    return {
+      valid: false,
+      error: "`metrics.testsPassing` must be a non-negative integer.",
+    };
+  }
+  if (!isNonNegativeInteger(m.featuresDelivered)) {
+    return {
+      valid: false,
+      error: "`metrics.featuresDelivered` must be a non-negative integer.",
+    };
+  }
+
+  // tags
+  if (!Array.isArray(b.tags) || b.tags.length > 10) {
+    return {
+      valid: false,
+      error: "`tags` must be an array with at most 10 items.",
+    };
+  }
+  if (!b.tags.every((t) => typeof t === "string")) {
+    return { valid: false, error: "`tags` must be an array of strings." };
+  }
+
+  return {
+    valid: true,
+    data: {
+      weekEnding: b.weekEnding as string,
+      headline: b.headline as string,
+      highlights: b.highlights as string[],
+      metrics: {
+        prsShipped: m.prsShipped as number,
+        testsPassing: m.testsPassing as number,
+        featuresDelivered: m.featuresDelivered as number,
+      },
+      tags: b.tags as string[],
+    },
+  };
+}
+
+export async function POST(req: Request) {
+  const authResult = await requireApiKey(req);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  const ip = getClientIp(req);
+
+  // Rate limit
+  const rateResult = await checkGenericRateLimit(RATE_LIMIT_CONFIG, ip);
+  if (rateResult.limited) {
+    return Errors.rateLimited(rateResult.retryAfter ?? 60);
+  }
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Errors.badRequest("Invalid JSON body.");
+  }
+
+  const validation = validateBody(body);
+  if (!validation.valid) {
+    return Errors.validationError(validation.error);
+  }
+
+  try {
+    const id = randomUUID();
+    const createdAt = new Date().toISOString();
+    const summary: ActivitySummary = {
+      id,
+      ...validation.data,
+      createdAt,
+    };
+
+    const blobPath = `${ACTIVITY_PREFIX}${summary.weekEnding}-${id}.json`;
+    await put(blobPath, JSON.stringify(summary), {
+      access: "public",
+      contentType: "application/json",
+    });
+
+    return apiSuccess(summary);
+  } catch (error) {
+    console.error("[api/v1/activity] Error storing activity summary:", error);
+    return Errors.internalError("Failed to store activity summary.");
+  }
+}
+
+export async function GET(req: Request) {
+  const authResult = await requireApiKey(req);
+  if (authResult instanceof Response) {
+    return authResult;
+  }
+
+  try {
+    const { searchParams } = new URL(req.url);
+    const rawLimit = parseInt(searchParams.get("limit") ?? "10", 10);
+    const limit = isNaN(rawLimit) ? 10 : Math.min(Math.max(1, rawLimit), 52);
+
+    const allBlobs: { pathname: string; url: string }[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = await list({
+        prefix: ACTIVITY_PREFIX,
+        cursor,
+        limit: 1000,
+      });
+      allBlobs.push(...result.blobs);
+      cursor = result.cursor ?? undefined;
+    } while (cursor);
+
+    // Fetch all blob contents
+    const summaries: ActivitySummary[] = [];
+    const fetchTimeout = 10000;
+
+    const fetchResults = await Promise.allSettled(
+      allBlobs.map(async (blob) => {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), fetchTimeout);
+        try {
+          const response = await fetch(blob.url, { signal: controller.signal });
+          if (!response.ok) throw new Error(`HTTP ${response.status}`);
+          return (await response.json()) as ActivitySummary;
+        } finally {
+          clearTimeout(timeoutId);
+        }
+      }),
+    );
+
+    for (const result of fetchResults) {
+      if (result.status === "fulfilled") {
+        summaries.push(result.value);
+      }
+    }
+
+    // Sort by weekEnding descending
+    summaries.sort((a, b) => {
+      if (b.weekEnding < a.weekEnding) return -1;
+      if (b.weekEnding > a.weekEnding) return 1;
+      return 0;
+    });
+
+    return apiSuccess(summaries.slice(0, limit));
+  } catch (error) {
+    console.error("[api/v1/activity] Error listing activity summaries:", error);
+    return Errors.internalError("Failed to list activity summaries.");
+  }
+}

--- a/src/lib/types/activity-summary.ts
+++ b/src/lib/types/activity-summary.ts
@@ -1,0 +1,13 @@
+export interface ActivitySummary {
+  id: string; // UUID
+  weekEnding: string; // ISO date string (the Sunday)
+  headline: string; // One-line summary, max 200 chars
+  highlights: string[]; // 3-7 bullet points of what shipped
+  metrics: {
+    prsShipped: number;
+    testsPassing: number;
+    featuresDelivered: number;
+  };
+  tags: string[]; // e.g. ["infrastructure", "api", "testing"]
+  createdAt: string; // ISO timestamp
+}

--- a/src/lib/types/index.ts
+++ b/src/lib/types/index.ts
@@ -1,3 +1,4 @@
 export type { FitAssessmentLog } from './fit-assessment-log';
 export type { AuditEvent, AuditEventType, TrafficSource, AuditEventMetadata } from './audit-event';
 export type { AdminSession, AdminTokenPayload } from './admin-session';
+export type { ActivitySummary } from './activity-summary';

--- a/tests/api/v1/activity.test.ts
+++ b/tests/api/v1/activity.test.ts
@@ -1,0 +1,424 @@
+/**
+ * @vitest-environment node
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock @vercel/blob
+const mockList = vi.fn();
+const mockPut = vi.fn();
+vi.mock("@vercel/blob", () => ({
+  list: (...args: unknown[]) => mockList(...args),
+  put: (...args: unknown[]) => mockPut(...args),
+}));
+
+// Mock api-key-auth
+const mockRequireApiKey = vi.fn();
+vi.mock("@/lib/api-key-auth", () => ({
+  requireApiKey: (req: Request) => mockRequireApiKey(req),
+}));
+
+// Mock rate-limit
+const mockCheckGenericRateLimit = vi.fn();
+vi.mock("@/lib/rate-limit", () => ({
+  getClientIp: vi.fn().mockReturnValue("127.0.0.1"),
+  checkGenericRateLimit: (...args: unknown[]) =>
+    mockCheckGenericRateLimit(...args),
+}));
+
+const mockValidApiKey = {
+  apiKey: { id: "key-1", name: "Test Key", enabled: true },
+};
+
+const validBody = {
+  weekEnding: "2026-02-22",
+  headline: "Shipped the activity feed API",
+  highlights: ["Built POST endpoint", "Built GET endpoint", "Added tests"],
+  metrics: {
+    prsShipped: 3,
+    testsPassing: 42,
+    featuresDelivered: 2,
+  },
+  tags: ["api", "testing"],
+};
+
+function makeRequest(
+  method: string,
+  body?: unknown,
+  url = "http://localhost/api/v1/activity",
+) {
+  return new Request(url, {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: body !== undefined ? JSON.stringify(body) : undefined,
+  });
+}
+
+describe("v1/activity API route", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockRequireApiKey.mockResolvedValue(mockValidApiKey);
+    mockCheckGenericRateLimit.mockResolvedValue({
+      limited: false,
+      remaining: 9,
+    });
+    mockPut.mockResolvedValue({ url: "https://blob.url/activity.json" });
+  });
+
+  describe("authentication", () => {
+    it("POST returns 401 without API key", async () => {
+      mockRequireApiKey.mockResolvedValue(
+        Response.json(
+          {
+            success: false,
+            error: { code: "UNAUTHORIZED", message: "API key required" },
+          },
+          { status: 401 },
+        ),
+      );
+
+      const { POST } = await import("@/app/api/v1/activity/route");
+      const response = await POST(makeRequest("POST", validBody));
+      expect(response.status).toBe(401);
+    });
+
+    it("GET returns 401 without API key", async () => {
+      mockRequireApiKey.mockResolvedValue(
+        Response.json(
+          {
+            success: false,
+            error: { code: "UNAUTHORIZED", message: "API key required" },
+          },
+          { status: 401 },
+        ),
+      );
+      mockList.mockResolvedValue({ blobs: [], cursor: undefined });
+
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(makeRequest("GET"));
+      expect(response.status).toBe(401);
+    });
+  });
+
+  describe("POST /api/v1/activity", () => {
+    describe("validation", () => {
+      it("returns 400 when body is missing", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const req = new Request("http://localhost/api/v1/activity", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: "not-json",
+        });
+        const response = await POST(req);
+        expect(response.status).toBe(400);
+      });
+
+      it("returns 400 when weekEnding is missing", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const { weekEnding: _weekEnding, ...rest } = validBody;
+        void _weekEnding;
+        const response = await POST(makeRequest("POST", rest));
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when weekEnding is invalid date", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", { ...validBody, weekEnding: "not-a-date" }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when headline exceeds 200 chars", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", { ...validBody, headline: "a".repeat(201) }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when highlights is empty array", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", { ...validBody, highlights: [] }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when highlights has more than 10 items", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", {
+            ...validBody,
+            highlights: Array(11).fill("item"),
+          }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when metrics has negative prsShipped", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", {
+            ...validBody,
+            metrics: { ...validBody.metrics, prsShipped: -1 },
+          }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when metrics has negative testsPassing", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", {
+            ...validBody,
+            metrics: { ...validBody.metrics, testsPassing: -5 },
+          }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when metrics has non-integer featuresDelivered", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", {
+            ...validBody,
+            metrics: { ...validBody.metrics, featuresDelivered: 1.5 },
+          }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 400 when tags has more than 10 items", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", { ...validBody, tags: Array(11).fill("tag") }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(400);
+        expect(data.error.code).toBe("VALIDATION_ERROR");
+      });
+
+      it("returns 429 when rate limited", async () => {
+        mockCheckGenericRateLimit.mockResolvedValue({
+          limited: true,
+          remaining: 0,
+          retryAfter: 45,
+        });
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(makeRequest("POST", validBody));
+        expect(response.status).toBe(429);
+      });
+    });
+
+    describe("success", () => {
+      it("returns created ActivitySummary with id and createdAt", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(makeRequest("POST", validBody));
+        const data = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(data.success).toBe(true);
+        expect(data.data).toMatchObject({
+          weekEnding: validBody.weekEnding,
+          headline: validBody.headline,
+          highlights: validBody.highlights,
+          metrics: validBody.metrics,
+          tags: validBody.tags,
+        });
+        expect(typeof data.data.id).toBe("string");
+        expect(data.data.id).toMatch(/^[0-9a-f-]{36}$/); // UUID format
+        expect(typeof data.data.createdAt).toBe("string");
+        expect(() => new Date(data.data.createdAt)).not.toThrow();
+      });
+
+      it("stores blob at correct path", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        await POST(makeRequest("POST", validBody));
+
+        expect(mockPut).toHaveBeenCalledWith(
+          expect.stringMatching(
+            /^damilola\.tech\/activity\/2026-02-22-[0-9a-f-]+\.json$/,
+          ),
+          expect.any(String),
+          expect.objectContaining({
+            access: "public",
+            contentType: "application/json",
+          }),
+        );
+      });
+
+      it("accepts empty tags array", async () => {
+        const { POST } = await import("@/app/api/v1/activity/route");
+        const response = await POST(
+          makeRequest("POST", { ...validBody, tags: [] }),
+        );
+        const data = await response.json();
+        expect(response.status).toBe(200);
+        expect(data.data.tags).toEqual([]);
+      });
+    });
+  });
+
+  describe("GET /api/v1/activity", () => {
+    const mockSummaries: Array<{ weekEnding: string; url: string }> = [
+      { weekEnding: "2026-02-22", url: "https://blob.url/a1.json" },
+      { weekEnding: "2026-02-15", url: "https://blob.url/a2.json" },
+      { weekEnding: "2026-02-08", url: "https://blob.url/a3.json" },
+    ];
+
+    function makeSummary(
+      weekEnding: string,
+      url: string,
+    ): { summary: object; url: string } {
+      return {
+        summary: {
+          id: "uuid-" + weekEnding,
+          weekEnding,
+          headline: `Week of ${weekEnding}`,
+          highlights: ["Did stuff"],
+          metrics: { prsShipped: 1, testsPassing: 10, featuresDelivered: 1 },
+          tags: [],
+          createdAt: new Date().toISOString(),
+        },
+        url,
+      };
+    }
+
+    beforeEach(() => {
+      const summaryData = mockSummaries.map((s) =>
+        makeSummary(s.weekEnding, s.url),
+      );
+
+      mockList.mockResolvedValue({
+        blobs: summaryData.map(({ url }, i) => ({
+          pathname: `damilola.tech/activity/${mockSummaries[i].weekEnding}-uuid.json`,
+          url,
+        })),
+        cursor: undefined,
+      });
+
+      // Mock fetch for blob contents
+      global.fetch = vi.fn().mockImplementation((url: string) => {
+        const item = summaryData.find((s) => s.url === url);
+        if (item) {
+          return Promise.resolve({
+            ok: true,
+            json: () => Promise.resolve(item.summary),
+          });
+        }
+        return Promise.resolve({ ok: false, status: 404 });
+      }) as unknown as typeof fetch;
+    });
+
+    it("returns summaries sorted by weekEnding descending", async () => {
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(makeRequest("GET"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      const weeks = data.data.map((s: { weekEnding: string }) => s.weekEnding);
+      expect(weeks).toEqual(["2026-02-22", "2026-02-15", "2026-02-08"]);
+    });
+
+    it("respects limit param", async () => {
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(
+        makeRequest(
+          "GET",
+          undefined,
+          "http://localhost/api/v1/activity?limit=2",
+        ),
+      );
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.data).toHaveLength(2);
+      expect(data.data[0].weekEnding).toBe("2026-02-22");
+    });
+
+    it("uses default limit of 10", async () => {
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(makeRequest("GET"));
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      // 3 summaries available, all returned (under default limit of 10)
+      expect(data.data).toHaveLength(3);
+    });
+
+    it("caps limit at 52", async () => {
+      mockList.mockResolvedValue({ blobs: [], cursor: undefined });
+      const { GET } = await import("@/app/api/v1/activity/route");
+      // Just verify it doesn't error; blobs are empty so result is empty
+      const response = await GET(
+        makeRequest(
+          "GET",
+          undefined,
+          "http://localhost/api/v1/activity?limit=100",
+        ),
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("handles blob fetch errors gracefully", async () => {
+      mockList.mockResolvedValue({
+        blobs: [
+          {
+            pathname: "damilola.tech/activity/2026-02-22-uuid.json",
+            url: "https://blob.url/fail.json",
+          },
+        ],
+        cursor: undefined,
+      });
+      global.fetch = vi.fn().mockResolvedValue({
+        ok: false,
+        status: 500,
+      }) as unknown as typeof fetch;
+
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(makeRequest("GET"));
+      const data = await response.json();
+
+      // Failed fetches are skipped
+      expect(response.status).toBe(200);
+      expect(data.data).toHaveLength(0);
+      consoleSpy.mockRestore();
+    });
+
+    it("handles list error gracefully", async () => {
+      mockList.mockRejectedValue(new Error("Blob store error"));
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      const { GET } = await import("@/app/api/v1/activity/route");
+      const response = await GET(makeRequest("GET"));
+      const data = await response.json();
+
+      expect(response.status).toBe(500);
+      expect(data.error.code).toBe("INTERNAL_ERROR");
+      consoleSpy.mockRestore();
+    });
+  });
+});


### PR DESCRIPTION
## Activity Feed API — Phase 1

Adds API endpoints to power the "Live Engineering Intelligence" showcase on damilola.tech. This is the data layer — the Cortex agent system will push weekly sanitized activity summaries via these endpoints.

### New Endpoints

| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/v1/activity` | Create a weekly activity summary |
| `GET` | `/api/v1/activity` | List summaries (sorted by week, supports `?limit=N`) |

Both require API key auth (`dk_*`).

### What's Included
- `src/app/api/v1/activity/route.ts` — POST + GET handlers with validation, rate limiting, Vercel Blob storage
- `src/lib/types/activity-summary.ts` — `ActivitySummary` type (weekEnding, headline, highlights, metrics, tags)
- `tests/api/v1/activity.test.ts` — 22 tests covering validation, auth, CRUD, edge cases

### Privacy Design
These endpoints only accept **pre-sanitized** data. The sanitization happens on the Cortex side (in a separate script) before any data reaches this API. The API itself stores and serves opaque activity summaries — it has no knowledge of internal infrastructure.

### Verification
- ✅ `npm run lint` — 0 errors
- ✅ `npx tsc --noEmit` — compiles clean
- ✅ `npx vitest run tests/api/v1/activity.test.ts` — 22/22 passing
- ✅ Prettier formatted

### Next Steps
- Phase 2: UI component on the Cortex project page to render these summaries
- Cortex cron job (Sunday 8pm MT) generates + pushes summaries with manual approval gate

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Added Activity Summary API with POST endpoint to create summaries and GET endpoint to retrieve them.
  * Integrated API key authentication and rate limiting for secure access.
  * Summaries are automatically persisted with metadata including metrics and tags.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->