### PR TITLE
fix(activity): read directly from Vercel Blob instead of self-authenticating API

### DIFF
--- a/src/app/projects/cortex/activity/page.tsx
+++ b/src/app/projects/cortex/activity/page.tsx
@@ -1,7 +1,10 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { list } from "@vercel/blob";
 import { Badge } from "@/components/ui";
 import type { ActivitySummary } from "@/lib/types/activity-summary";
+
+export const revalidate = 3600;
 
 export const metadata: Metadata = {
   title: "Engineering Activity — Cortex Agent Fleet | Damilola Elegbede",
@@ -9,25 +12,37 @@ export const metadata: Metadata = {
     "Weekly engineering activity from the Cortex multi-agent system — PRs shipped, features delivered, and highlights from each week.",
 };
 
+const ACTIVITY_PREFIX = "damilola.tech/activity/";
+
 async function getActivityData(): Promise<ActivitySummary[]> {
   try {
-    const baseUrl =
-      process.env.NEXT_PUBLIC_BASE_URL ??
-      (process.env.VERCEL_URL
-        ? `https://${process.env.VERCEL_URL}`
-        : "http://localhost:3000");
+    const allBlobs: { url: string }[] = [];
+    let cursor: string | undefined;
+    do {
+      const result = await list({ prefix: ACTIVITY_PREFIX, cursor, limit: 1000 });
+      allBlobs.push(...result.blobs);
+      cursor = result.cursor ?? undefined;
+    } while (cursor);
 
-    const response = await fetch(`${baseUrl}/api/v1/activity?limit=52`, {
-      headers: {
-        "x-api-key": process.env.DK_API_KEY ?? "",
-      },
-      next: { revalidate: 3600 },
-    });
+    const summaries: ActivitySummary[] = [];
+    const results = await Promise.allSettled(
+      allBlobs.map(async (blob) => {
+        const response = await fetch(blob.url, {
+          signal: AbortSignal.timeout(10000),
+        });
+        if (!response.ok) throw new Error(`HTTP ${response.status}`);
+        return (await response.json()) as ActivitySummary;
+      }),
+    );
 
-    if (!response.ok) return [];
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        summaries.push(result.value);
+      }
+    }
 
-    const json = await response.json();
-    return Array.isArray(json?.data) ? json.data : [];
+    summaries.sort((a, b) => (b.weekEnding < a.weekEnding ? -1 : b.weekEnding > a.weekEnding ? 1 : 0));
+    return summaries.slice(0, 52);
   } catch {
     return [];
   }

--- a/tests/app/projects/cortex/activity.test.tsx
+++ b/tests/app/projects/cortex/activity.test.tsx
@@ -19,6 +19,12 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// Mock @vercel/blob
+const mockList = vi.fn();
+vi.mock("@vercel/blob", () => ({
+  list: (...args: unknown[]) => mockList(...args),
+}));
+
 const mockSummary: ActivitySummary = {
   id: "abc-123",
   weekEnding: "2026-02-22",
@@ -32,10 +38,24 @@ const mockSummary: ActivitySummary = {
 // We test the page as an async server component by calling it directly
 // and awaiting the result rendered with render()
 async function renderPage(summaries: ActivitySummary[]) {
-  global.fetch = vi.fn().mockResolvedValue({
-    ok: true,
-    json: () => Promise.resolve({ data: summaries }),
-  } as unknown as Response);
+  // Mock blob list to return blob URLs for each summary
+  const blobs = summaries.map((s, i) => ({
+    url: `https://blob.vercel-storage.com/activity-${i}.json`,
+    pathname: `damilola.tech/activity/${s.weekEnding}-${s.id}.json`,
+  }));
+  mockList.mockResolvedValue({ blobs, cursor: undefined });
+
+  // Mock fetch to return summary data when fetching blob URLs
+  global.fetch = vi.fn().mockImplementation((url: string) => {
+    const index = blobs.findIndex((b) => b.url === url);
+    if (index >= 0) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(summaries[index]),
+      } as unknown as Response);
+    }
+    return Promise.resolve({ ok: false } as unknown as Response);
+  });
 
   // Dynamic import so mock is in place first
   const { default: Page } = await import(


### PR DESCRIPTION
## Problem

The activity page (`/projects/cortex/activity`) was calling its own `/api/v1/activity` endpoint with `DK_API_KEY` via the `x-api-key` header. This meant the Vercel deployment needed `DK_API_KEY` as an environment variable just to render its own page — the app was authenticating with itself, which is unnecessary.

Without the env var, the page silently returned an empty array and showed "No engineering activity recorded yet" even though data existed in blob storage.

## Fix

Replace the self-authenticating API call with a direct `@vercel/blob` `list()` call. The page is a server component — it can read from blob storage directly without going through the authenticated API layer.

**Before:** page → fetch(`/api/v1/activity`) with API key → blob store → render
**After:** page → `list()` from blob store → render

## Changes

- `src/app/projects/cortex/activity/page.tsx` — replace fetch-from-self with direct blob read
- `tests/app/projects/cortex/activity.test.tsx` — mock `@vercel/blob` instead of `fetch`

## Verification

- ✅ Build passes
- ✅ 7/7 tests pass
- ✅ API endpoint (`POST /api/v1/activity`) remains unchanged — external writes still require auth


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance & Reliability**
  * Enhanced activity data retrieval with improved error handling and parallel processing
  * Optimized data caching strategy for better page performance
  * More resilient handling of data source failures and timeouts
  * Activity data now displays the latest 52 entries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->