### PR TITLE
test(ats-scorer): add unit and integration tests for ATS scoring engine

### DIFF
--- a/src/lib/__tests__/ats-scorer.test.ts
+++ b/src/lib/__tests__/ats-scorer.test.ts
@@ -260,9 +260,16 @@ describe('Keyword matching', () => {
     const result = calculateATSScore(makeInput());
     const matched = new Set(result.details.matchedKeywords.map((k) => k.toLowerCase()));
     const missing = new Set(result.details.missingKeywords.map((k) => k.toLowerCase()));
+    const all = new Set(result.details.extractedKeywords.all.map((k) => k.toLowerCase()));
     // No overlap between matched and missing
     for (const kw of matched) {
       expect(missing.has(kw)).toBe(false);
+    }
+    // Union of matched + missing must equal extractedKeywords.all
+    const union = new Set([...matched, ...missing]);
+    expect(union.size).toBe(all.size);
+    for (const kw of all) {
+      expect(union.has(kw)).toBe(true);
     }
   });
 
@@ -740,10 +747,6 @@ const MASTERS_RESUME_DATA: ResumeData = {
   experiences: [{ title: 'ML Engineer', company: 'Corp', highlights: ['Training models'] }],
 };
 
-// ---------------------------------------------------------------------------
-// 10. Integration — scoring a generated resumeDataToText
-// ---------------------------------------------------------------------------
-
 describe('Integration: resumeDataToText → calculateATSScore', () => {
   it('text generated from structured data scores above zero against its JD', () => {
     const generatedText = resumeDataToText({ ...RICH_RESUME_DATA, name: 'Jane Smith' });
@@ -912,8 +915,8 @@ describe('Education matching', () => {
     });
     const mastersResult = calculateATSScore({
       jobDescription: PHD_JD,
-      resumeText: resumeDataToText({ ...sharedData, education: [{ degree: 'Master of Science in Computer Science', institution: 'CMU' }] }),
-      resumeData: { ...sharedData, education: [{ degree: 'Master of Science in Computer Science', institution: 'CMU' }] },
+      resumeText: resumeDataToText({ ...sharedData, education: MASTERS_RESUME_DATA.education }),
+      resumeData: { ...sharedData, education: MASTERS_RESUME_DATA.education },
     });
 
     // Both scores must be valid


### PR DESCRIPTION
Closes #87

Adds comprehensive vitest test suite for the ATS scoring engine to prevent future regressions.

Covers:
- [x] Score ceiling (never > 100)
- [x] Score floor (never < 0)
- [x] Keyword matching (exact, fuzzy, none)
- [x] Role-fit penalty
- [x] Keyword cap
- [x] Max possible score consistency
- [x] Edge cases (empty inputs, nulls)

All tests pass deterministically with no network calls.

## Test Results
- **77 tests** — all passing
- **0 flaky** — fully deterministic, no network calls, no random seeds

## Coverage Notes
Statement coverage on `ats-scorer.ts` is ~51% through the public API. The gap is caused by four internal helper functions (`calculateKeywordScore`, `calculateSkillsScore`, `calculateExperienceScore`, `calculateMatchQuality`) that are defined in the file but never called — they are dead code unreachable through the exported API. Removing or exporting these functions would push coverage above 80%. This is flagged as a follow-up cleanup item.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an extensive unit and integration test suite for the ATS scorer covering score bounds and invariants, keyword matching and density, role‑fit and management vs IC scenarios, education and skill coverage, determinism, edge cases (empty/missing fields), resumeData→text serialization, section completeness, end‑to‑end scoring, and rich fixture scenarios for broad coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->