### PR TITLE
fix: resolve undici CVE by updating @vercel/blob (#96)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@modelcontextprotocol/sdk": "^1.26.0",
         "@react-pdf/renderer": "^4.3.2",
         "@upstash/redis": "^1.36.1",
-        "@vercel/blob": "^2.0.0",
+        "@vercel/blob": "^2.3.1",
         "ai": "^6.0.39",
         "clsx": "^2.1.1",
         "geist": "^1.5.1",
@@ -1308,15 +1308,6 @@
         "@noble/hashes": {
           "optional": true
         }
-      }
-    },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=14"
       }
     },
     "node_modules/@hono/node-server": {
@@ -3952,16 +3943,16 @@
       }
     },
     "node_modules/@vercel/blob": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.0.0.tgz",
-      "integrity": "sha512-oAj7Pdy83YKSwIaMFoM7zFeLYWRc+qUpW3PiDSblxQMnGFb43qs4bmfq7dr/+JIfwhs6PTwe1o2YBwKhyjWxXw==",
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@vercel/blob/-/blob-2.3.1.tgz",
+      "integrity": "sha512-6f9oWC+DbWxIgBLOdqjjn2/REpFrPDB7y5B5HA1ptYkzZaBgL6E34kWrptJvJ7teApJdbAs3I1a5A7z1y8SDHw==",
       "license": "Apache-2.0",
       "dependencies": {
         "async-retry": "^1.3.3",
         "is-buffer": "^2.0.5",
         "is-node-process": "^1.2.0",
         "throttleit": "^2.1.0",
-        "undici": "^5.28.4"
+        "undici": "^6.23.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -11934,15 +11925,12 @@
       "license": "MIT"
     },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "6.24.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+      "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=18.17"
       }
     },
     "node_modules/undici-types": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@react-pdf/renderer": "^4.3.2",
     "@upstash/redis": "^1.36.1",
-    "@vercel/blob": "^2.0.0",
+    "@vercel/blob": "^2.3.1",
     "ai": "^6.0.39",
     "clsx": "^2.1.1",
     "geist": "^1.5.1",


### PR DESCRIPTION
Fixes #96 by updating @vercel/blob to resolve the undici high severity CVE.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Vercel Blob library to a newer version, including any maintenance improvements and bug fixes from the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->