### PR TITLE
fix(resume-pdf): prevent bullet point splitting across page breaks

### DIFF
--- a/src/lib/resume-pdf.tsx
+++ b/src/lib/resume-pdf.tsx
@@ -501,7 +501,7 @@ function ResumePDF({ data, analysis, acceptedIndices, effectiveChanges, showFoot
         {/* Professional Experience */}
         <Text style={styles.sectionHeader}>Professional Experience</Text>
         {resume.experience.map((job, jobIndex) => (
-          <View key={jobIndex} style={styles.job}>
+          <View key={jobIndex} style={styles.job} minPresenceAhead={20}>
             {/* Company | Location */}
             <View style={styles.jobCompanyLine}>
               <Text style={styles.companyBold}>{job.company}</Text>
@@ -516,9 +516,9 @@ function ResumePDF({ data, analysis, acceptedIndices, effectiveChanges, showFoot
             {job.description && (
               <Text style={styles.jobDescription}>{job.description}</Text>
             )}
-            {/* Bullets - wrap={true} allows long text to flow to next line */}
-            {job.responsibilities.map((responsibility, bulletIndex) => (
-              <View key={bulletIndex} style={styles.bulletContainer} wrap={true}>
+            {/* Bullets - wrap={false} keeps bullet+text as atomic unit across page breaks */}
+            {job.responsibilities.filter((r) => r.trim()).map((responsibility, bulletIndex) => (
+              <View key={bulletIndex} style={styles.bulletContainer} wrap={false}>
                 <Text style={styles.bullet}>•</Text>
                 <Text style={styles.bulletText}>{responsibility}</Text>
               </View>


### PR DESCRIPTION
## Summary
- Set `wrap={false}` on bullet container `<View>` to keep `•` and its text as an atomic unit — prevents the bullet character from stranding at page bottom while text flows to next page
- Filter empty/whitespace-only responsibilities to prevent blank bullets rendering
- Add `minPresenceAhead={20}` on job headers to keep them visually near their content across page breaks

## Test plan
- [x] `npm run typecheck` passes
- [x] `npm run test` passes (127 files, 2523 tests)
- [ ] Generate a resume PDF and visually confirm no split bullets or orphaned job headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Optimized resume PDF page-breaking for professional experience sections to prevent awkward splits
* Removed blank bullet points and improved text wrapping for job responsibilities in generated PDFs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->