### PR TITLE
feat: add interview stage field to ApplicationTracker

### DIFF
--- a/src/app/api/v1/log-application/[id]/route.ts
+++ b/src/app/api/v1/log-application/[id]/route.ts
@@ -1,0 +1,65 @@
+import { requireApiKey } from '@/lib/api-key-auth';
+import { Errors } from '@/lib/api-response';
+import { updateApplicationStage } from '@/lib/applications-store';
+import { APPLICATION_STAGES } from '@/lib/types/application';
+import type { ApplicationStage } from '@/lib/types/application';
+
+export const runtime = 'nodejs';
+
+export async function PATCH(
+  req: Request,
+  { params }: { params: Promise<{ id: string }> }
+): Promise<Response> {
+  const authResult = await requireApiKey(req);
+  if (authResult instanceof Response) return authResult;
+
+  const { id } = await params;
+
+  let body: unknown;
+  try {
+    body = await req.json();
+  } catch {
+    return Errors.badRequest('Invalid JSON body.');
+  }
+
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return Errors.validationError('Request body must be a JSON object.');
+  }
+
+  const b = body as Record<string, unknown>;
+  const rawStage = b['stage'];
+
+  if (rawStage === undefined || rawStage === null) {
+    return Errors.validationError('missing required field: stage');
+  }
+
+  if (!APPLICATION_STAGES.includes(rawStage as ApplicationStage)) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `invalid stage value: '${String(rawStage)}'`,
+        },
+      },
+      { status: 422 }
+    );
+  }
+
+  const updated = await updateApplicationStage(id, rawStage as ApplicationStage);
+
+  if (!updated) {
+    return Response.json(
+      {
+        success: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: `application '${id}' not found`,
+        },
+      },
+      { status: 404 }
+    );
+  }
+
+  return Response.json({ success: true, data: updated });
+}

--- a/src/app/api/v1/log-application/[id]/route.ts
+++ b/src/app/api/v1/log-application/[id]/route.ts
@@ -46,7 +46,13 @@ export async function PATCH(
     );
   }
 
-  const updated = await updateApplicationStage(id, rawStage as ApplicationStage);
+  let updated: Awaited<ReturnType<typeof updateApplicationStage>>;
+  try {
+    updated = await updateApplicationStage(id, rawStage as ApplicationStage);
+  } catch (err) {
+    console.error('[PATCH /api/v1/log-application] updateApplicationStage failed:', err);
+    return Errors.internalError('Failed to update application stage.');
+  }
 
   if (!updated) {
     return Response.json(

--- a/src/app/api/v1/log-application/route.ts
+++ b/src/app/api/v1/log-application/route.ts
@@ -5,6 +5,8 @@ import { saveApplication, listApplicationIds, getApplications } from '@/lib/appl
 import { APPLICATION_STATUSES } from '@/lib/types/application';
 import type { Application, ApplicationStatus } from '@/lib/types/application';
 
+// stage always defaults to 'Applied' on creation — advancement via PATCH /[id]
+
 export const runtime = 'nodejs';
 
 export async function POST(req: Request): Promise<Response> {
@@ -99,6 +101,7 @@ export async function POST(req: Request): Promise<Response> {
     role_id,
     applied_at,
     status,
+    stage: 'Applied',
     score,
     notes,
     cover_letter_draft,

--- a/src/lib/applications-store.ts
+++ b/src/lib/applications-store.ts
@@ -120,6 +120,11 @@ export async function updateApplicationStage(
 
   const raw = await client.hgetall(hashKey);
   if (!raw || Object.keys(raw).length === 0) return null;
+  // TOCTOU guard: if hset raced with a delete, the hash may be partial
+  if (!raw['created_at']) {
+    await client.del(hashKey);
+    return null;
+  }
   return deserialize(raw as Record<string, string>);
 }
 

--- a/src/lib/applications-store.ts
+++ b/src/lib/applications-store.ts
@@ -7,7 +7,7 @@
  */
 
 import { Redis } from '@upstash/redis';
-import type { Application } from '@/lib/types/application';
+import type { Application, ApplicationStage } from '@/lib/types/application';
 
 // Redis key helpers
 const HASH_KEY = (id: string) => `applications:${id}`;
@@ -42,6 +42,7 @@ export async function saveApplication(app: Application): Promise<void> {
     role_id: app.role_id ?? '',
     applied_at: app.applied_at,
     status: app.status,
+    stage: app.stage ?? 'Applied',
     score: app.score !== null ? String(app.score) : '',
     notes: app.notes ?? '',
     cover_letter_draft: app.cover_letter_draft ?? '',
@@ -100,6 +101,28 @@ export async function getApplications(ids: string[]): Promise<Application[]> {
   return apps;
 }
 
+/**
+ * Update the interview stage on an existing application.
+ * Returns the updated record, or null if the application does not exist.
+ */
+export async function updateApplicationStage(
+  id: string,
+  stage: ApplicationStage
+): Promise<Application | null> {
+  const client = getRedis();
+  const hashKey = HASH_KEY(id);
+
+  const exists = await client.exists(hashKey);
+  if (!exists) return null;
+
+  const now = new Date().toISOString();
+  await client.hset(hashKey, { stage, updated_at: now });
+
+  const raw = await client.hgetall(hashKey);
+  if (!raw || Object.keys(raw).length === 0) return null;
+  return deserialize(raw as Record<string, string>);
+}
+
 function deserialize(raw: Record<string, string>): Application {
   return {
     id: raw['id'] ?? '',
@@ -109,6 +132,7 @@ function deserialize(raw: Record<string, string>): Application {
     role_id: raw['role_id'] || null,
     applied_at: raw['applied_at'] ?? '',
     status: (raw['status'] ?? 'applied') as Application['status'],
+    stage: (raw['stage'] || 'Applied') as Application['stage'],
     score: raw['score'] !== '' && raw['score'] !== undefined ? Number(raw['score']) : null,
     notes: raw['notes'] || null,
     cover_letter_draft: raw['cover_letter_draft'] || null,

--- a/src/lib/types/application.ts
+++ b/src/lib/types/application.ts
@@ -13,6 +13,16 @@ export const APPLICATION_STATUSES = [
 
 export type ApplicationStatus = (typeof APPLICATION_STATUSES)[number];
 
+export const APPLICATION_STAGES = [
+  'Applied',
+  'PhoneScreen',
+  'Technical',
+  'Offer',
+  'Rejected',
+] as const;
+
+export type ApplicationStage = (typeof APPLICATION_STAGES)[number];
+
 export interface Application {
   id: string;
   company: string;
@@ -21,6 +31,7 @@ export interface Application {
   role_id: string | null;
   applied_at: string; // ISO-Z
   status: ApplicationStatus;
+  stage: ApplicationStage; // interview stage, defaults to 'Applied'
   score: number | null; // 0–100
   notes: string | null;
   cover_letter_draft?: string | null;
@@ -31,5 +42,5 @@ export interface Application {
 /** Subset returned in POST 201 and GET list items */
 export type ApplicationSummary = Pick<
   Application,
-  'id' | 'company' | 'title' | 'applied_at' | 'status' | 'score' | 'url' | 'notes' | 'role_id' | 'cover_letter_draft'
+  'id' | 'company' | 'title' | 'applied_at' | 'status' | 'stage' | 'score' | 'url' | 'notes' | 'role_id' | 'cover_letter_draft'
 >;

--- a/tests/app/api/v1-applications.test.ts
+++ b/tests/app/api/v1-applications.test.ts
@@ -26,6 +26,7 @@ const makeApp = (overrides: Partial<Application> = {}): Application => ({
   role_id: null,
   applied_at: '2026-04-23T14:00:00Z',
   status: 'applied',
+  stage: 'Applied',
   score: 88,
   notes: null,
   created_at: '2026-04-23T14:00:00Z',

--- a/tests/app/api/v1-log-application-stage.test.ts
+++ b/tests/app/api/v1-log-application-stage.test.ts
@@ -1,0 +1,104 @@
+/**
+ * @vitest-environment node
+ *
+ * Tests for interview stage field:
+ *   1. POST /api/v1/log-application — stage defaults to 'Applied'
+ *   2. PATCH /api/v1/log-application/:id — advances stage successfully
+ *   3. PATCH /api/v1/log-application/:id — returns 422 for invalid stage
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock api-key-auth
+const mockRequireApiKey = vi.fn();
+vi.mock('@/lib/api-key-auth', () => ({
+  requireApiKey: (req: Request) => mockRequireApiKey(req),
+}));
+
+// Mock applications-store for POST tests
+const mockSaveApplication = vi.fn();
+const mockUpdateApplicationStage = vi.fn();
+vi.mock('@/lib/applications-store', () => ({
+  saveApplication: (...args: unknown[]) => mockSaveApplication(...args),
+  updateApplicationStage: (...args: unknown[]) => mockUpdateApplicationStage(...args),
+}));
+
+vi.mock('crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('crypto')>();
+  return { ...actual, randomUUID: vi.fn().mockReturnValue('stage-test-uuid') };
+});
+
+const mockValidApiKey = { apiKey: { id: 'key-1', name: 'Test Key', enabled: true } };
+
+describe('Application stage field', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    mockRequireApiKey.mockResolvedValue(mockValidApiKey);
+    mockSaveApplication.mockResolvedValue(undefined);
+  });
+
+  it('POST /api/v1/log-application — stage defaults to Applied when not provided', async () => {
+    const { POST } = await import('@/app/api/v1/log-application/route');
+
+    const req = new Request('http://localhost/api/v1/log-application', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ company: 'Anthropic', title: 'Staff Engineer' }),
+    });
+    await POST(req);
+
+    expect(mockSaveApplication).toHaveBeenCalledOnce();
+    const saved = mockSaveApplication.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved['stage']).toBe('Applied');
+  });
+
+  it('PATCH /api/v1/log-application/:id — advances stage to PhoneScreen', async () => {
+    const updatedApp = {
+      id: 'app-123',
+      company: 'Anthropic',
+      title: 'Staff Engineer',
+      stage: 'PhoneScreen',
+      status: 'applied',
+      applied_at: '2026-04-26T00:00:00Z',
+      score: null,
+      url: null,
+      role_id: null,
+      notes: null,
+      created_at: '2026-04-26T00:00:00Z',
+      updated_at: '2026-04-26T15:00:00Z',
+    };
+    mockUpdateApplicationStage.mockResolvedValue(updatedApp);
+
+    const { PATCH } = await import('@/app/api/v1/log-application/[id]/route');
+
+    const req = new Request('http://localhost/api/v1/log-application/app-123', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stage: 'PhoneScreen' }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: 'app-123' }) });
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data.stage).toBe('PhoneScreen');
+    expect(mockUpdateApplicationStage).toHaveBeenCalledWith('app-123', 'PhoneScreen');
+  });
+
+  it('PATCH /api/v1/log-application/:id — returns 422 for invalid stage value', async () => {
+    const { PATCH } = await import('@/app/api/v1/log-application/[id]/route');
+
+    const req = new Request('http://localhost/api/v1/log-application/app-123', {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ stage: 'InvalidStage' }),
+    });
+    const res = await PATCH(req, { params: Promise.resolve({ id: 'app-123' }) });
+    const data = await res.json();
+
+    expect(res.status).toBe(422);
+    expect(data.success).toBe(false);
+    expect(data.error.message).toContain('InvalidStage');
+    expect(mockUpdateApplicationStage).not.toHaveBeenCalled();
+  });
+});

--- a/tests/app/api/v1-log-application-stage.test.ts
+++ b/tests/app/api/v1-log-application-stage.test.ts
@@ -49,6 +49,7 @@ describe('Application stage field', () => {
 
     expect(mockSaveApplication).toHaveBeenCalledOnce();
     const saved = mockSaveApplication.mock.calls[0][0] as Record<string, unknown>;
+    expect(saved['id']).toBe('stage-test-uuid');
     expect(saved['stage']).toBe('Applied');
   });
 


### PR DESCRIPTION
## Summary

- Adds `stage` enum (`Applied`, `PhoneScreen`, `Technical`, `Offer`, `Rejected`) to the `Application` type and Upstash Redis store
- `POST /api/v1/log-application` sets `stage: 'Applied'` by default (no breaking change to existing callers)
- New `PATCH /api/v1/log-application/:id` endpoint accepts `{ stage }` to advance interview stage
- `GET /api/v1/applications` returns `stage` on every record (additive field)

## Test plan
- [x] 3 new tests: `POST` defaults to `Applied`, `PATCH` advances to `PhoneScreen`, `PATCH` returns 422 for invalid stage
- [x] 33 existing `v1-log-application` + `v1-applications` tests all pass
- [x] TypeScript typecheck clean (excluding pre-existing worktree errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Applications now track interview stages: Applied, Phone Screen, Technical, Offer, Rejected
  * New endpoint to update an application's stage
  * New applications default to stage "Applied" when created
  * Stage updates validate input and return structured errors for invalid data or missing records

* **Tests**
  * Added tests covering stage initialization, successful stage updates, and invalid-stage validation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->