### PR TITLE
feat(admin): add /admin/applications Kanban job pipeline view

### DIFF
--- a/src/app/admin/applications/page.tsx
+++ b/src/app/admin/applications/page.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import type { Application, ApplicationStatus } from '@/lib/types/application';
+
+const COLUMNS: { status: ApplicationStatus; label: string }[] = [
+  { status: 'applied', label: 'Applied' },
+  { status: 'screen', label: 'Screening' },
+  { status: 'interview', label: 'Interview' },
+  { status: 'offer', label: 'Offer' },
+  { status: 'rejected', label: 'Rejected' },
+];
+
+function sortByScore(apps: Application[]): Application[] {
+  return [...apps].sort((a, b) => {
+    if (a.score === null && b.score === null) return 0;
+    if (a.score === null) return 1;
+    if (b.score === null) return -1;
+    return b.score - a.score;
+  });
+}
+
+function ScoreChip({ score }: { score: number | null }) {
+  if (score === null) return null;
+  const color =
+    score >= 85
+      ? 'bg-green-500/15 text-green-400'
+      : score >= 70
+      ? 'bg-yellow-500/15 text-yellow-400'
+      : 'bg-red-500/15 text-red-400';
+  return (
+    <span className={`rounded px-1.5 py-0.5 text-xs font-medium ${color}`}>{score}</span>
+  );
+}
+
+function AppCard({ app }: { app: Application }) {
+  const appliedDate = new Date(app.applied_at).toLocaleDateString('en-US', {
+    month: 'short',
+    day: 'numeric',
+  });
+
+  return (
+    <div className="rounded-lg border border-[var(--color-border)] bg-[var(--color-bg)] p-3 text-sm">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="truncate font-medium text-[var(--color-text)]">{app.company}</p>
+          <p className="truncate text-[var(--color-text-muted)]">{app.title}</p>
+        </div>
+        <ScoreChip score={app.score} />
+      </div>
+      <div className="mt-2 flex items-center justify-between gap-2">
+        <span className="text-xs text-[var(--color-text-muted)]">{appliedDate}</span>
+        {app.url && (
+          <a
+            href={app.url}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-xs text-[var(--color-accent)] hover:underline"
+          >
+            JD ↗
+          </a>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ApplicationsPage() {
+  const [applications, setApplications] = useState<Application[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    fetch('/api/admin/applications')
+      .then((res) => {
+        if (!res.ok) throw new Error('Failed to fetch applications');
+        return res.json();
+      })
+      .then((data) => setApplications(data.data.applications ?? []))
+      .catch((err) => setError(err instanceof Error ? err.message : 'An error occurred'))
+      .finally(() => setIsLoading(false));
+  }, []);
+
+  if (isLoading) {
+    return (
+      <div
+        className="flex h-64 items-center justify-center"
+        role="status"
+        aria-label="Loading applications"
+        aria-live="polite"
+        aria-busy="true"
+      >
+        <div className="h-8 w-8 animate-spin rounded-full border-2 border-[var(--color-accent)] border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="rounded-lg border border-red-500/30 bg-red-500/10 p-4 text-red-400">
+        {error}
+      </div>
+    );
+  }
+
+  const byStatus = Object.fromEntries(
+    COLUMNS.map(({ status }) => [
+      status,
+      sortByScore(applications.filter((a) => a.status === status)),
+    ])
+  );
+
+  const total = applications.length;
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h1 className="text-2xl font-semibold text-[var(--color-text)]">Job Pipeline</h1>
+        <p className="mt-1 text-sm text-[var(--color-text-muted)]">
+          {total} application{total !== 1 ? 's' : ''} tracked
+        </p>
+      </div>
+
+      <div className="grid grid-cols-5 gap-4">
+        {COLUMNS.map(({ status, label }) => {
+          const cards = byStatus[status] ?? [];
+          return (
+            <div key={status} className="flex flex-col gap-3">
+              <div className="flex items-center justify-between">
+                <span className="text-xs font-semibold uppercase tracking-wider text-[var(--color-text-muted)]">
+                  {label}
+                </span>
+                <span className="rounded-full bg-[var(--color-bg-alt)] px-2 py-0.5 text-xs text-[var(--color-text-muted)]">
+                  {cards.length}
+                </span>
+              </div>
+              <div className="flex flex-col gap-2">
+                {cards.length === 0 ? (
+                  <p className="text-xs text-[var(--color-text-muted)] opacity-50">—</p>
+                ) : (
+                  cards.map((app) => <AppCard key={app.id} app={app} />)
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/app/api/admin/applications/route.ts
+++ b/src/app/api/admin/applications/route.ts
@@ -1,0 +1,22 @@
+import { cookies } from 'next/headers';
+import { verifyToken, ADMIN_COOKIE_NAME } from '@/lib/admin-auth';
+import { listApplicationIds, getApplications } from '@/lib/applications-store';
+
+export const runtime = 'nodejs';
+
+export async function GET(_req: Request) {
+  const cookieStore = await cookies();
+  const token = cookieStore.get(ADMIN_COOKIE_NAME)?.value;
+  if (!token || !(await verifyToken(token))) {
+    return Response.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  try {
+    const allIds = await listApplicationIds();
+    const applications = await getApplications(allIds);
+    return Response.json({ success: true, data: { applications } });
+  } catch (err) {
+    console.error('[api/admin/applications] Failed to list applications:', err);
+    return Response.json({ error: 'Failed to list applications' }, { status: 500 });
+  }
+}

--- a/src/components/admin/AdminNav.tsx
+++ b/src/components/admin/AdminNav.tsx
@@ -10,6 +10,7 @@ const navItems = [
   { href: '/admin/usage', label: 'Usage', icon: 'M12 8c-1.657 0-3 .895-3 2s1.343 2 3 2 3 .895 3 2-1.343 2-3 2m0-8c1.11 0 2.08.402 2.599 1M12 8V7m0 1v8m0 0v1m0-1c-1.11 0-2.08-.402-2.599-1M21 12a9 9 0 11-18 0 9 9 0 0118 0z' },
   { href: '/admin/chats', label: 'Chats', icon: 'M8 12h.01M12 12h.01M16 12h.01M21 12c0 4.418-4.03 8-9 8a9.863 9.863 0 01-4.255-.949L3 20l1.395-3.72C3.512 15.042 3 13.574 3 12c0-4.418 4.03-8 9-8s9 3.582 9 8z' },
   { href: '/admin/fit-assessments', label: 'Fit Assessments', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-3 7h3m-3 4h3m-6-4h.01M9 16h.01' },
+  { href: '/admin/applications', label: 'Job Pipeline', icon: 'M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4' },
   { href: '/admin/resume-generator', label: 'Resume Generator', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },
   { href: '/admin/api-keys', label: 'API Keys', icon: 'M15 7a2 2 0 012 2m4 0a6 6 0 01-7.743 5.743L11 17H9v2H7v2H4a1 1 0 01-1-1v-2.586a1 1 0 01.293-.707l5.964-5.964A6 6 0 1121 9z' },
   { href: '/admin/audit', label: 'Audit Log', icon: 'M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z' },

--- a/tests/components/admin/admin-nav.test.tsx
+++ b/tests/components/admin/admin-nav.test.tsx
@@ -27,7 +27,9 @@ describe('AdminNav', () => {
     expect(screen.getByText('Usage')).toBeInTheDocument();
     expect(screen.getByText('Chats')).toBeInTheDocument();
     expect(screen.getByText('Fit Assessments')).toBeInTheDocument();
+    expect(screen.getByText('Job Pipeline')).toBeInTheDocument();
     expect(screen.getByText('Resume Generator')).toBeInTheDocument();
+    expect(screen.getByText('API Keys')).toBeInTheDocument();
     expect(screen.getByText('Audit Log')).toBeInTheDocument();
     expect(screen.getByText('Docs')).toBeInTheDocument();
   });
@@ -45,7 +47,9 @@ describe('AdminNav', () => {
     const usageLink = screen.getByText('Usage').closest('a');
     const chatsLink = screen.getByText('Chats').closest('a');
     const fitAssessmentsLink = screen.getByText('Fit Assessments').closest('a');
+    const jobPipelineLink = screen.getByText('Job Pipeline').closest('a');
     const resumeGeneratorLink = screen.getByText('Resume Generator').closest('a');
+    const apiKeysLink = screen.getByText('API Keys').closest('a');
     const auditLogLink = screen.getByText('Audit Log').closest('a');
     const docsLink = screen.getByText('Docs').closest('a');
 
@@ -54,7 +58,9 @@ describe('AdminNav', () => {
     expect(usageLink).toHaveAttribute('href', '/admin/usage');
     expect(chatsLink).toHaveAttribute('href', '/admin/chats');
     expect(fitAssessmentsLink).toHaveAttribute('href', '/admin/fit-assessments');
+    expect(jobPipelineLink).toHaveAttribute('href', '/admin/applications');
     expect(resumeGeneratorLink).toHaveAttribute('href', '/admin/resume-generator');
+    expect(apiKeysLink).toHaveAttribute('href', '/admin/api-keys');
     expect(auditLogLink).toHaveAttribute('href', '/admin/audit');
     expect(docsLink).toHaveAttribute('href', '/admin/docs');
   });
@@ -110,8 +116,8 @@ describe('AdminNav', () => {
 
     // Each nav item has an SVG icon
     const svgElements = container.querySelectorAll('svg');
-    // 9 nav items + 1 logout button = 10 SVG icons
-    expect(svgElements.length).toBe(10);
+    // 10 nav items + 1 logout button = 11 SVG icons
+    expect(svgElements.length).toBe(11);
   });
 
   it('applies hover styles to inactive links', () => {


### PR DESCRIPTION
## Summary

- New admin API route `/api/admin/applications` with JWT session auth (same cookie-based auth as all admin routes)
- 5-column Kanban view at `/admin/applications`: Applied / Screening / Interview / Offer / Rejected
- Each card shows: company, role title, date applied, color-coded score chip (green ≥85, yellow ≥70, red <70), JD link if stored
- Cards sorted by score descending within each column (unscored apps sort last)
- Added **Job Pipeline** nav link in AdminNav sidebar
- Simple table-based layout per spec (no drag-and-drop)

## Test plan
- [ ] Navigate to `/admin/applications` — 5 columns visible
- [ ] At least 1 application card visible with company, role, date
- [ ] Score chip color-coded correctly
- [ ] JD link opens in new tab when present
- [ ] Unauthenticated request to `/api/admin/applications` returns 401

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Job Pipeline admin dashboard showing applications by status columns with per-column counts and a placeholder when empty.
  * Application cards display company, title, applied date, external job link, and numerical score with color-coded chips (green/yellow/red).
* **Navigation**
  * Admin menu adds a "Job Pipeline" link.
* **UX Improvements**
  * Loading and error states for the dashboard.
* **Tests**
  * Updated admin navigation tests to include the new entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->