### PR TITLE
feat(score-job): add interview-prep mode — return 5 behavioral questions from gap analysis (ENG-127)

### DIFF
--- a/src/app/api/v1/score-job/route.ts
+++ b/src/app/api/v1/score-job/route.ts
@@ -146,8 +146,8 @@ export async function POST(req: Request) {
 
     const basePrompt = buildGapAnalysisPrompt(currentScore);
     const userContent = interviewPrepMode
-      ? `${basePrompt}\n\nAdditionally, return exactly 5 "interviewPrepQuestions" in the JSON. Each must use behavioral framing — start with "Tell me about a time..." or "How would you approach...". Base questions on the top gap areas identified above.\n\nUpdated JSON schema: {"gapAnalysis":"...","maxPossibleScore":0-100,"recommendation":"...","interviewPrepQuestions":["Q1","Q2","Q3","Q4","Q5"]}\n\n<job_description>${xmlEscape(resolvedInput.text)}</job_description>`
-      : `${basePrompt}\n\n<job_description>${xmlEscape(resolvedInput.text)}</job_description>`;
+      ? `${basePrompt}\n\nAdditionally, return exactly 5 "interviewPrepQuestions" in the JSON. Each must use behavioral framing — start with "Tell me about a time..." or "How would you approach...". Base questions on the top gap areas identified above.\n\nUpdated JSON schema: {"gapAnalysis":"...","maxPossibleScore":0-100,"recommendation":"...","interviewPrepQuestions":["Q1","Q2","Q3","Q4","Q5"]}\n\n<job_description>${xmlEscape(scoringText)}</job_description>`
+      : `${basePrompt}\n\n<job_description>${xmlEscape(scoringText)}</job_description>`;
 
     const message = await scoringClient.messages.create({
       model: 'claude-opus-4-6',
@@ -172,9 +172,10 @@ export async function POST(req: Request) {
     const parsed = parseJsonResponse(responseText);
 
     const gapAnalysis = typeof parsed.gapAnalysis === 'string' ? parsed.gapAnalysis : '';
-    const interviewPrepQuestions = interviewPrepMode && Array.isArray(parsed.interviewPrepQuestions)
+    const _rawPrepQuestions = interviewPrepMode && Array.isArray(parsed.interviewPrepQuestions)
       ? (parsed.interviewPrepQuestions as unknown[]).slice(0, 5).filter((q): q is string => typeof q === 'string')
       : undefined;
+    const interviewPrepQuestions = _rawPrepQuestions?.length === 5 ? _rawPrepQuestions : undefined;
     const parsedMaxScore = sanitizeScoreValue(parsed.maxPossibleScore, 0, 100);
     const maxPossibleScore = Math.max(currentScore.total, parsedMaxScore);
     const gap = maxPossibleScore - currentScore.total;

--- a/src/app/api/v1/score-job/route.ts
+++ b/src/app/api/v1/score-job/route.ts
@@ -173,7 +173,11 @@ export async function POST(req: Request) {
 
     const gapAnalysis = typeof parsed.gapAnalysis === 'string' ? parsed.gapAnalysis : '';
     const _rawPrepQuestions = interviewPrepMode && Array.isArray(parsed.interviewPrepQuestions)
-      ? (parsed.interviewPrepQuestions as unknown[]).slice(0, 5).filter((q): q is string => typeof q === 'string')
+      ? (parsed.interviewPrepQuestions as unknown[])
+          .filter((q): q is string => typeof q === 'string')
+          .map((q) => q.trim())
+          .filter((q) => q.length > 0)
+          .slice(0, 5)
       : undefined;
     const interviewPrepQuestions = _rawPrepQuestions?.length === 5 ? _rawPrepQuestions : undefined;
     const parsedMaxScore = sanitizeScoreValue(parsed.maxPossibleScore, 0, 100);

--- a/src/app/api/v1/score-job/route.ts
+++ b/src/app/api/v1/score-job/route.ts
@@ -90,7 +90,13 @@ export async function POST(req: Request) {
       return Errors.validationError('Request body must be a JSON object.');
     }
 
-    const { url, title, company, job_content: jobContent } = body as Record<string, unknown>;
+    const { url, title, company, job_content: jobContent, mode } = body as Record<string, unknown>;
+
+    if (mode !== undefined && mode !== null && mode !== 'interview-prep') {
+      return Errors.badRequest('Invalid mode. Accepted values: "interview-prep".');
+    }
+    const interviewPrepMode = mode === 'interview-prep';
+
     const normalizedUrl = typeof url === 'string' ? url.trim() : url;
     const normalizedTitle = typeof title === 'string' ? title.trim() : title;
     const normalizedCompany = typeof company === 'string' ? company.trim() : company;
@@ -138,9 +144,14 @@ export async function POST(req: Request) {
     const { readinessScore } = buildScoringInput(scoringText);
     const currentScore = buildScorePayload(readinessScore);
 
+    const basePrompt = buildGapAnalysisPrompt(currentScore);
+    const userContent = interviewPrepMode
+      ? `${basePrompt}\n\nAdditionally, return exactly 5 "interviewPrepQuestions" in the JSON. Each must use behavioral framing — start with "Tell me about a time..." or "How would you approach...". Base questions on the top gap areas identified above.\n\nUpdated JSON schema: {"gapAnalysis":"...","maxPossibleScore":0-100,"recommendation":"...","interviewPrepQuestions":["Q1","Q2","Q3","Q4","Q5"]}\n\n<job_description>${xmlEscape(resolvedInput.text)}</job_description>`
+      : `${basePrompt}\n\n<job_description>${xmlEscape(resolvedInput.text)}</job_description>`;
+
     const message = await scoringClient.messages.create({
       model: 'claude-opus-4-6',
-      max_tokens: 1200,
+      max_tokens: interviewPrepMode ? 2000 : 1200,
       temperature: 0,
       system: [
         {
@@ -152,7 +163,7 @@ export async function POST(req: Request) {
       messages: [
         {
           role: 'user',
-          content: `${buildGapAnalysisPrompt(currentScore)}\n\n<job_description>${xmlEscape(resolvedInput.text)}</job_description>`,
+          content: userContent,
         },
       ],
     });
@@ -161,6 +172,9 @@ export async function POST(req: Request) {
     const parsed = parseJsonResponse(responseText);
 
     const gapAnalysis = typeof parsed.gapAnalysis === 'string' ? parsed.gapAnalysis : '';
+    const interviewPrepQuestions = interviewPrepMode && Array.isArray(parsed.interviewPrepQuestions)
+      ? (parsed.interviewPrepQuestions as unknown[]).slice(0, 5).filter((q): q is string => typeof q === 'string')
+      : undefined;
     const parsedMaxScore = sanitizeScoreValue(parsed.maxPossibleScore, 0, 100);
     const maxPossibleScore = Math.max(currentScore.total, parsedMaxScore);
     const gap = maxPossibleScore - currentScore.total;
@@ -194,6 +208,7 @@ export async function POST(req: Request) {
       gapAnalysis,
       recommendation,
       ...(resolvedInput.isEmptyShell ? { emptyShellFallback: true } : {}),
+      ...(interviewPrepQuestions ? { interviewPrepQuestions } : {}),
     });
   } catch (error) {
     if (error instanceof JobDescriptionInputError) {

--- a/tests/api/v1/score-job.test.ts
+++ b/tests/api/v1/score-job.test.ts
@@ -438,5 +438,37 @@ describe('POST /api/v1/score-job', () => {
       );
       expect(allBehavioral).toBe(true);
     });
+
+    it('omits interviewPrepQuestions when AI returns mixed-type array (strings and numbers)', async () => {
+      mockParseJsonResponse.mockReturnValue({
+        gapAnalysis: 'Strong fit.',
+        maxPossibleScore: 88,
+        recommendation: 'marginal_improvement',
+        interviewPrepQuestions: ['Q1', 2, 'Q3', 4, 'Q5'],
+      });
+
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: 'interview-prep' }));
+      const data = await response.json() as { success: boolean; data: Record<string, unknown> };
+
+      expect(response.status).toBe(200);
+      expect(data.data.interviewPrepQuestions).toBeUndefined();
+    });
+
+    it('omits interviewPrepQuestions when AI returns fewer than 5 items', async () => {
+      mockParseJsonResponse.mockReturnValue({
+        gapAnalysis: 'Strong fit.',
+        maxPossibleScore: 88,
+        recommendation: 'marginal_improvement',
+        interviewPrepQuestions: ['Q1', 'Q2', 'Q3'],
+      });
+
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: 'interview-prep' }));
+      const data = await response.json() as { success: boolean; data: Record<string, unknown> };
+
+      expect(response.status).toBe(200);
+      expect(data.data.interviewPrepQuestions).toBeUndefined();
+    });
   });
 });

--- a/tests/api/v1/score-job.test.ts
+++ b/tests/api/v1/score-job.test.ts
@@ -358,4 +358,85 @@ describe('POST /api/v1/score-job', () => {
       expect(response.status).toBe(500);
     });
   });
+
+  describe('interview-prep mode', () => {
+    const prepQuestions = [
+      'Tell me about a time you designed a scalable distributed system.',
+      'How would you approach leading a team through a major architectural migration?',
+      'Tell me about a time you had to balance technical debt against feature velocity.',
+      'How would you approach mentoring engineers on Kubernetes-based infrastructure?',
+      'Tell me about a time you drove cross-functional alignment on a technical decision.',
+    ];
+
+    beforeEach(() => {
+      mockParseJsonResponse.mockReturnValue({
+        gapAnalysis: 'Strong fit.',
+        maxPossibleScore: 88,
+        recommendation: 'marginal_improvement',
+        interviewPrepQuestions: prepQuestions,
+      });
+    });
+
+    it('returns interviewPrepQuestions with exactly 5 items when mode=interview-prep', async () => {
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: 'interview-prep' }));
+      const data = await response.json() as { success: boolean; data: Record<string, unknown> };
+
+      expect(response.status).toBe(200);
+      expect(data.success).toBe(true);
+      expect(Array.isArray(data.data.interviewPrepQuestions)).toBe(true);
+      expect((data.data.interviewPrepQuestions as string[]).length).toBe(5);
+    });
+
+    it('response does not include interviewPrepQuestions when mode is absent', async () => {
+      mockParseJsonResponse.mockReturnValue({
+        gapAnalysis: 'Strong fit.',
+        maxPossibleScore: 88,
+        recommendation: 'marginal_improvement',
+      });
+
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest(validBody));
+      const data = await response.json() as { success: boolean; data: Record<string, unknown> };
+
+      expect(response.status).toBe(200);
+      expect(data.data.interviewPrepQuestions).toBeUndefined();
+    });
+
+    it('response does not include interviewPrepQuestions when mode is null', async () => {
+      mockParseJsonResponse.mockReturnValue({
+        gapAnalysis: 'Strong fit.',
+        maxPossibleScore: 88,
+        recommendation: 'marginal_improvement',
+      });
+
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: null }));
+      const data = await response.json() as { success: boolean; data: Record<string, unknown> };
+
+      expect(response.status).toBe(200);
+      expect(data.data.interviewPrepQuestions).toBeUndefined();
+    });
+
+    it('returns 400 with Invalid mode error when mode is an unrecognized string', async () => {
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: 'invalid-mode' }));
+      const data = await response.json() as { error: { message: string } };
+
+      expect(response.status).toBe(400);
+      expect(data.error.message).toContain('Invalid mode');
+    });
+
+    it('questions use behavioral framing (Tell me about or How would you)', async () => {
+      const { POST } = await import('@/app/api/v1/score-job/route');
+      const response = await POST(makeRequest({ ...validBody, mode: 'interview-prep' }));
+      const data = await response.json() as { data: { interviewPrepQuestions: string[] } };
+
+      const questions = data.data.interviewPrepQuestions;
+      const allBehavioral = questions.every(
+        (q) => q.startsWith('Tell me about') || q.startsWith('How would you')
+      );
+      expect(allBehavioral).toBe(true);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds interview-prep mode to `/api/v1/score-job` so D can get a fit score **and** a prep plan in one call.

- `POST /api/v1/score-job` now accepts optional `"mode": "interview-prep"` in the request body
- When `mode=interview-prep`: response includes `interviewPrepQuestions: string[]` — exactly 5 behavioral questions ("Tell me about a time..." / "How would you approach...") derived from the top `gapAnalysis` items
- When `mode` is absent or `null`: response shape unchanged (no regression)
- Invalid mode value → HTTP 400 `{ error: { message: "Invalid mode..." } }`

Closes ENG-127

## Example request

```bash
curl -X POST /api/v1/score-job \
  -H "X-Api-Key: $KEY" \
  -d '{"url":"https://anthropic.com/jobs/123","title":"Staff Engineer","company":"Anthropic","mode":"interview-prep"}'
```

## Example response (trimmed)

```json
{
  "success": true,
  "data": {
    "currentScore": { "total": 72, ... },
    "gapAnalysis": "Strong systems-design depth but missing ML infra signals...",
    "recommendation": "marginal_improvement",
    "interviewPrepQuestions": [
      "Tell me about a time you designed a fault-tolerant distributed system at scale.",
      "How would you approach building ML training infrastructure for a large language model?",
      "Tell me about a time you led a cross-functional team through a major platform migration.",
      "How would you approach mentoring engineers on reliability engineering practices?",
      "Tell me about a time you had to balance technical debt against a hard product deadline."
    ]
  }
}
```

## Test plan

- [x] 5 new unit tests added (TDD — tests written before implementation)
- [x] All 26 score-job tests pass (21 original + 5 new)
- [x] TypeScript clean (no new errors)
- [x] No regression to existing mode-absent behavior
- [x] Invalid mode returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an interview-prep mode to the scoring API: when enabled, responses include exactly five curated behavioral interview questions alongside scoring results; invalid mode values return a clear error.

* **Tests**
  * Added tests for interview-prep behavior (positive/negative cases), validation, and handling of malformed or incomplete AI responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->