### PR TITLE
docs: note robots.txt /api/ crawl exclusion (ENG-496)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -48,6 +48,8 @@ Comprehensive documentation for the damilola.tech personal career landing page a
 - [SSRF Protection](./api-documentation.md#ssrf-protection) - URL fetching security
 - [Input Validation](./api-documentation.md#input-validation) - Request sanitization
 
+All `/api/` and `/admin/` routes are intentionally excluded from search engine crawlers via `src/app/robots.ts` — the sitemap publishes only public routes.
+
 ## Development
 
 ### Setup


### PR DESCRIPTION
## Summary

- Adds one sentence to the Security section of `docs/README.md` noting that `/api/` and `/admin/` routes are excluded from crawler indexing via `src/app/robots.ts`
- Gap-fill for PR#152 (merged 2026-05-13), which added `app/robots.ts` with the disallow rules but left no docs trail

## Changes

- `docs/README.md` — added one sentence under the existing Security section; no other files touched

## Test plan

- [ ] Confirm the sentence renders correctly in Markdown preview
- [ ] Confirm `src/app/robots.ts` still disallows `/admin/` and `/api/`
- [ ] Confirm diff touches only `docs/README.md`

Closes ENG-496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that API and admin routes are excluded from search engine crawling and the sitemap contains only public routes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/damilola-elegbede-org/damilola.tech/pull/172)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->